### PR TITLE
feat: add HATEOAS links to all endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,27 @@ ___
 > baseURL: https://mcuapi.up.railway.app/api/v1
 
 > docs: https://mcuapi.up.railway.app/docs
+
+### 🔗 Hypermedia (HATEOAS)
+
+Every resource includes a HAL-style `_links` object with navigable relations:
+
+```json
+{
+  "id": 1,
+  "title": "Iron Man",
+  "_links": {
+    "self": { "href": "https://mcuapi.up.railway.app/api/v1/movies/1" },
+    "characters": { "href": "https://mcuapi.up.railway.app/api/v1/characters/movie/1" }
+  }
+}
+```
+
+List endpoints (`/movies`, `/tvshows`, `/characters`) also return `page`, `limit` and collection `_links` (`self`, `first`, `last`, plus `prev`/`next` when paginating with the `limit` query param), preserving all other query params.
+
+Characters are fully navigable via `GET /characters/{id}/movies` and `GET /characters/{id}/tvshows`, which list every movie/TV show a character appears in (with `role_type`).
+
+> Links are built from the request host by default. Set the optional `APP_URL` environment variable (e.g. `APP_URL=https://mcuapi.up.railway.app`) to force the base URL behind a proxy.
 ---
 
 ## 🆕 Next features <a name="next-features"></a>

--- a/SETUP.md
+++ b/SETUP.md
@@ -27,6 +27,8 @@ DB_PASS=postgres
 DB_NAME=mcuapi
 ```
 
+Optional: set `APP_URL` (e.g. `APP_URL=https://mcuapi.up.railway.app`) to force the base URL used in the `_links` hypermedia fields; when unset, links are built from the request host.
+
 ---
 
 ## 2. API Backend (mcuapi)

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,7 +19,9 @@ module.exports = {
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
   collectCoverageFrom: [
-    '<rootDir>/src/modules/**/services/*.ts'
+    '<rootDir>/src/modules/**/services/*.ts',
+    '<rootDir>/src/modules/**/infra/http/presenters/*.ts',
+    '<rootDir>/src/shared/infra/http/hateoas/*.ts',
   ],
 
   // The directory where Jest should output its coverage files

--- a/src/config/swagger.json
+++ b/src/config/swagger.json
@@ -126,6 +126,24 @@
                     "total": {
                       "type": "integer",
                       "description": "Total of movies"
+                    },
+                    "page": {
+                      "type": "integer",
+                      "description": "Current page (1 when not paginated)",
+                      "example": 1
+                    },
+                    "limit": {
+                      "type": "integer",
+                      "description": "Items per page (present only when the limit query param is used)",
+                      "example": 10
+                    },
+                    "_links": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/ResourceLinks"
+                        }
+                      ],
+                      "description": "Collection links: self, first, last, and prev/next when applicable. All original query params are preserved."
                     }
                   }
                 }
@@ -323,6 +341,24 @@
                     "total": {
                       "type": "integer",
                       "description": "Total of tv shows"
+                    },
+                    "page": {
+                      "type": "integer",
+                      "description": "Current page (1 when not paginated)",
+                      "example": 1
+                    },
+                    "limit": {
+                      "type": "integer",
+                      "description": "Items per page (present only when the limit query param is used)",
+                      "example": 10
+                    },
+                    "_links": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/ResourceLinks"
+                        }
+                      ],
+                      "description": "Collection links: self, first, last, and prev/next when applicable. All original query params are preserved."
                     }
                   }
                 }
@@ -486,6 +522,24 @@
                     "total": {
                       "type": "integer",
                       "description": "Total of characters"
+                    },
+                    "page": {
+                      "type": "integer",
+                      "description": "Current page (1 when not paginated)",
+                      "example": 1
+                    },
+                    "limit": {
+                      "type": "integer",
+                      "description": "Items per page (present only when the limit query param is used)",
+                      "example": 10
+                    },
+                    "_links": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/ResourceLinks"
+                        }
+                      ],
+                      "description": "Collection links: self, first, last, and prev/next when applicable. All original query params are preserved."
                     }
                   }
                 }
@@ -694,6 +748,164 @@
           }
         }
       }
+    },
+    "/api/v1/characters/{character_id}/movies": {
+      "get": {
+        "tags": [
+          "Characters"
+        ],
+        "summary": "Get movies a character appears in",
+        "description": "Get all movies a specific character appears in, with the role type of each appearance",
+        "parameters": [
+          {
+            "name": "character_id",
+            "in": "path",
+            "description": "Character ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "example": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/Movie"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "role_type": {
+                            "type": "string",
+                            "description": "Character's role in the movie (main, supporting, cameo)",
+                            "example": "main"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Character not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    },
+                    "statusCode": {
+                      "type": "integer"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "example": {
+                    "status": "Error",
+                    "statusCode": 404,
+                    "message": "Character not found"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v1/characters/{character_id}/tvshows": {
+      "get": {
+        "tags": [
+          "Characters"
+        ],
+        "summary": "Get TV shows a character appears in",
+        "description": "Get all TV shows a specific character appears in, with the role type of each appearance",
+        "parameters": [
+          {
+            "name": "character_id",
+            "in": "path",
+            "description": "Character ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "example": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/TVShow"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "role_type": {
+                            "type": "string",
+                            "description": "Character's role in the tv show (main, supporting, cameo)",
+                            "example": "main"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Character not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    },
+                    "statusCode": {
+                      "type": "integer"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "example": {
+                    "status": "Error",
+                    "statusCode": 404,
+                    "message": "Character not found"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -806,6 +1018,9 @@
             "type": "string",
             "format": "date-time",
             "description": "Timestamp of the last update to the movie record"
+          },
+          "_links": {
+            "$ref": "#/components/schemas/ResourceLinks"
           }
         }
       },
@@ -917,6 +1132,9 @@
             "type": "string",
             "format": "date-time",
             "description": "Timestamp of the last update to the tv show record"
+          },
+          "_links": {
+            "$ref": "#/components/schemas/ResourceLinks"
           }
         }
       },
@@ -982,6 +1200,9 @@
             "type": "string",
             "format": "date-time",
             "description": "When the character was last updated"
+          },
+          "_links": {
+            "$ref": "#/components/schemas/ResourceLinks"
           }
         }
       },
@@ -1028,6 +1249,43 @@
             "type": "string",
             "description": "Content type (movie or tvshow)",
             "example": "movie"
+          },
+          "_links": {
+            "$ref": "#/components/schemas/ResourceLinks"
+          }
+        }
+      },
+      "Link": {
+        "type": "object",
+        "properties": {
+          "href": {
+            "type": "string",
+            "example": "https://mcuapi.example.com/api/v1/movies/1"
+          }
+        }
+      },
+      "ResourceLinks": {
+        "type": "object",
+        "description": "HAL-style hypermedia links. Each relation maps to a Link or an array of Links.",
+        "additionalProperties": {
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/Link"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Link"
+              }
+            }
+          ]
+        },
+        "example": {
+          "self": {
+            "href": "https://mcuapi.example.com/api/v1/movies/1"
+          },
+          "characters": {
+            "href": "https://mcuapi.example.com/api/v1/characters/movie/1"
           }
         }
       }

--- a/src/modules/characters/infra/http/controllers/CharactersController.ts
+++ b/src/modules/characters/infra/http/controllers/CharactersController.ts
@@ -5,6 +5,16 @@ import ListAllCharactersService from '@modules/characters/services/ListAllCharac
 import ShowCharacterService from '@modules/characters/services/ShowCharacterService';
 import GetCharactersByMovieService from '@modules/characters/services/GetCharactersByMovieService';
 import GetCharactersByTVShowService from '@modules/characters/services/GetCharactersByTVShowService';
+import GetMoviesByCharacterService from '@modules/characters/services/GetMoviesByCharacterService';
+import GetTVShowsByCharacterService from '@modules/characters/services/GetTVShowsByCharacterService';
+import {
+  presentCharacter,
+  presentCharacterArray,
+  presentCharacterCollection,
+} from '@modules/characters/infra/http/presenters/CharacterPresenter';
+import { presentMovie } from '@modules/movies/infra/http/presenters/MoviePresenter';
+import { presentTVShow } from '@modules/tvshows/infra/http/presenters/TVShowPresenter';
+import { getBaseUrl } from '@shared/infra/http/hateoas';
 
 interface IRequestQuery {
   page?: number;
@@ -39,7 +49,17 @@ export default class CharactersController {
       multiverse_designation,
     });
 
-    return response.status(200).json({ data, total });
+    return response.status(200).json(
+      presentCharacterCollection({
+        data,
+        total,
+        page,
+        limit,
+        baseUrl: getBaseUrl(request),
+        path: request.baseUrl + request.path,
+        query: request.query,
+      }),
+    );
   }
 
   public async show(request: Request, response: Response): Promise<Response> {
@@ -49,7 +69,7 @@ export default class CharactersController {
 
     const character = await showCharacter.execute({ character_id: Number(character_id) });
 
-    return response.status(200).json(character);
+    return response.status(200).json(presentCharacter(character, getBaseUrl(request)));
   }
 
   public async getByMovie(request: Request, response: Response): Promise<Response> {
@@ -58,7 +78,7 @@ export default class CharactersController {
     const getCharactersByMovie = container.resolve(GetCharactersByMovieService);
     const characters = await getCharactersByMovie.execute(Number(movie_id));
 
-    return response.status(200).json(characters);
+    return response.status(200).json(presentCharacterArray(characters, getBaseUrl(request)));
   }
 
   public async getByTVShow(request: Request, response: Response): Promise<Response> {
@@ -67,6 +87,28 @@ export default class CharactersController {
     const getCharactersByTVShow = container.resolve(GetCharactersByTVShowService);
     const characters = await getCharactersByTVShow.execute(Number(tvshow_id));
 
-    return response.status(200).json(characters);
+    return response.status(200).json(presentCharacterArray(characters, getBaseUrl(request)));
+  }
+
+  public async getMovies(request: Request, response: Response): Promise<Response> {
+    const { character_id } = request.params;
+
+    const getMoviesByCharacter = container.resolve(GetMoviesByCharacterService);
+    const movies = await getMoviesByCharacter.execute(Number(character_id));
+
+    const baseUrl = getBaseUrl(request);
+
+    return response.status(200).json(movies.map(movie => presentMovie(movie, baseUrl)));
+  }
+
+  public async getTVShows(request: Request, response: Response): Promise<Response> {
+    const { character_id } = request.params;
+
+    const getTVShowsByCharacter = container.resolve(GetTVShowsByCharacterService);
+    const tvshows = await getTVShowsByCharacter.execute(Number(character_id));
+
+    const baseUrl = getBaseUrl(request);
+
+    return response.status(200).json(tvshows.map(tvshow => presentTVShow(tvshow, baseUrl)));
   }
 }

--- a/src/modules/characters/infra/http/presenters/CharacterPresenter.spec.ts
+++ b/src/modules/characters/infra/http/presenters/CharacterPresenter.spec.ts
@@ -1,0 +1,79 @@
+import ICharacter from '@modules/characters/entities/ICharacter';
+import IMovie from '@modules/movies/entities/IMovie';
+import { presentCharacter, presentCharacterArray } from './CharacterPresenter';
+
+const baseUrl = 'http://localhost:3333';
+
+const character: ICharacter = {
+  id: 7,
+  name: 'Loki',
+  continuity: 'MCU',
+};
+
+describe('CharacterPresenter', () => {
+  it('Should add self, movies and tvshows links', () => {
+    const presented = presentCharacter(character, baseUrl);
+
+    expect(presented._links.self).toEqual({ href: `${baseUrl}/api/v1/characters/7` });
+    expect(presented._links.movies).toEqual({ href: `${baseUrl}/api/v1/characters/7/movies` });
+    expect(presented._links.tvshows).toEqual({ href: `${baseUrl}/api/v1/characters/7/tvshows` });
+  });
+
+  it('Should omit variant_of and first_appearance links when the FKs are null', () => {
+    const presented = presentCharacter(character, baseUrl);
+
+    expect(presented._links.variant_of).toBeUndefined();
+    expect(presented._links.first_appearance_movie).toBeUndefined();
+    expect(presented._links.first_appearance_tvshow).toBeUndefined();
+  });
+
+  it('Should link variant_of and first appearances from the FK columns', () => {
+    const presented = presentCharacter(
+      {
+        ...character,
+        variant_of: 3,
+        first_appearance_movie_id: 5,
+        first_appearance_tvshow_id: 9,
+      },
+      baseUrl,
+    );
+
+    expect(presented._links.variant_of).toEqual({ href: `${baseUrl}/api/v1/characters/3` });
+    expect(presented._links.first_appearance_movie).toEqual({ href: `${baseUrl}/api/v1/movies/5` });
+    expect(presented._links.first_appearance_tvshow).toEqual({ href: `${baseUrl}/api/v1/tvshows/9` });
+  });
+
+  it('Should add self-only links to embedded relation objects', () => {
+    const presented = presentCharacter(
+      {
+        ...character,
+        first_appearance_movie_id: 5,
+        first_appearance_movie: { id: 5, title: 'Thor' } as IMovie,
+      },
+      baseUrl,
+    );
+
+    expect(presented.first_appearance_movie).toMatchObject({
+      id: 5,
+      _links: { self: { href: `${baseUrl}/api/v1/movies/5` } },
+    });
+  });
+
+  it('Should preserve role_type on array items', () => {
+    const presented = presentCharacterArray([{ ...character, role_type: 'main' }], baseUrl);
+
+    expect(presented[0].role_type).toBe('main');
+    expect(presented[0]._links.self).toEqual({ href: `${baseUrl}/api/v1/characters/7` });
+  });
+
+  it('Should skip id-dependent links when id is missing but keep FK links', () => {
+    const presented = presentCharacter(
+      { name: 'Loki', variant_of: 3 } as ICharacter,
+      baseUrl,
+    );
+
+    expect(presented._links.self).toBeUndefined();
+    expect(presented._links.movies).toBeUndefined();
+    expect(presented._links.variant_of).toEqual({ href: `${baseUrl}/api/v1/characters/3` });
+  });
+});

--- a/src/modules/characters/infra/http/presenters/CharacterPresenter.ts
+++ b/src/modules/characters/infra/http/presenters/CharacterPresenter.ts
@@ -1,0 +1,113 @@
+import ICharacter from '@modules/characters/entities/ICharacter';
+import IMovie from '@modules/movies/entities/IMovie';
+import ITVShow from '@modules/tvshows/entities/ITVShow';
+import {
+  IResourceLinks,
+  WithLinks,
+  buildPaginationLinks,
+} from '@shared/infra/http/hateoas';
+
+type ICharacterWithRelations = ICharacter & {
+  variant_character?: ICharacter;
+  first_appearance_movie?: IMovie;
+  first_appearance_tvshow?: ITVShow;
+  role_type?: string;
+};
+
+interface IPresentCharacterCollectionParams {
+  data: ICharacter[];
+  total: number;
+  page?: number | string;
+  limit?: number | string;
+  baseUrl: string;
+  path: string;
+  query: Record<string, unknown>;
+}
+
+function withSelfLink<T extends { id?: number }>(
+  entity: T | undefined,
+  selfHref: (id: number) => string,
+): (T & { _links: IResourceLinks }) | undefined {
+  if (!entity) return undefined;
+
+  return {
+    ...entity,
+    _links: entity.id != null ? { self: { href: selfHref(entity.id) } } : {},
+  };
+}
+
+export function presentCharacter(
+  character: ICharacterWithRelations,
+  baseUrl: string,
+): WithLinks<ICharacterWithRelations> {
+  const _links: IResourceLinks = {};
+
+  if (character.id != null) {
+    _links.self = { href: `${baseUrl}/api/v1/characters/${character.id}` };
+    _links.movies = { href: `${baseUrl}/api/v1/characters/${character.id}/movies` };
+    _links.tvshows = { href: `${baseUrl}/api/v1/characters/${character.id}/tvshows` };
+  }
+
+  if (character.variant_of != null) {
+    _links.variant_of = { href: `${baseUrl}/api/v1/characters/${character.variant_of}` };
+  }
+
+  if (character.first_appearance_movie_id != null) {
+    _links.first_appearance_movie = {
+      href: `${baseUrl}/api/v1/movies/${character.first_appearance_movie_id}`,
+    };
+  }
+
+  if (character.first_appearance_tvshow_id != null) {
+    _links.first_appearance_tvshow = {
+      href: `${baseUrl}/api/v1/tvshows/${character.first_appearance_tvshow_id}`,
+    };
+  }
+
+  const variant_character = withSelfLink(
+    character.variant_character,
+    id => `${baseUrl}/api/v1/characters/${id}`,
+  );
+  const first_appearance_movie = withSelfLink(
+    character.first_appearance_movie,
+    id => `${baseUrl}/api/v1/movies/${id}`,
+  );
+  const first_appearance_tvshow = withSelfLink(
+    character.first_appearance_tvshow,
+    id => `${baseUrl}/api/v1/tvshows/${id}`,
+  );
+
+  return {
+    ...character,
+    ...(variant_character && { variant_character }),
+    ...(first_appearance_movie && { first_appearance_movie }),
+    ...(first_appearance_tvshow && { first_appearance_tvshow }),
+    _links,
+  };
+}
+
+export function presentCharacterArray(
+  characters: ICharacterWithRelations[],
+  baseUrl: string,
+): Array<WithLinks<ICharacterWithRelations>> {
+  return characters.map(character => presentCharacter(character, baseUrl));
+}
+
+export function presentCharacterCollection({
+  data,
+  total,
+  page,
+  limit,
+  baseUrl,
+  path,
+  query,
+}: IPresentCharacterCollectionParams) {
+  const { _links, meta } = buildPaginationLinks({ baseUrl, path, query, page, limit, total });
+
+  return {
+    data: presentCharacterArray(data, baseUrl),
+    total,
+    ...meta,
+    _links,
+  };
+}

--- a/src/modules/characters/infra/http/routes/characters.routes.ts
+++ b/src/modules/characters/infra/http/routes/characters.routes.ts
@@ -8,6 +8,8 @@ const charactersController = new CharactersController();
 charactersRouter.get('/', charactersController.index);
 charactersRouter.get('/movie/:movie_id', charactersController.getByMovie);
 charactersRouter.get('/tvshow/:tvshow_id', charactersController.getByTVShow);
+charactersRouter.get('/:character_id/movies', charactersController.getMovies);
+charactersRouter.get('/:character_id/tvshows', charactersController.getTVShows);
 charactersRouter.get('/:character_id', charactersController.show);
 
 export default charactersRouter; 

--- a/src/modules/characters/infra/typeorm/repositories/CharactersRepository.ts
+++ b/src/modules/characters/infra/typeorm/repositories/CharactersRepository.ts
@@ -1,5 +1,7 @@
-import { Repository, getRepository, Raw } from 'typeorm';
+import { Repository, getRepository, Raw, Not, IsNull } from 'typeorm';
 
+import IMovie from '@modules/movies/entities/IMovie';
+import ITVShow from '@modules/tvshows/entities/ITVShow';
 import ICharactersRepository from '@modules/characters/repositories/ICharactersRepository';
 import ICreateCharacterDTO from '@modules/characters/dtos/ICreateCharacterDTO';
 import IFindAllCharactersDTO from '@modules/characters/dtos/IFindAllCharactersDTO';
@@ -121,6 +123,36 @@ class CharactersRepository implements ICharactersRepository {
 
     return appearances.map(appearance => ({
       ...appearance.character,
+      role_type: appearance.role_type,
+    }));
+  }
+
+  public async findMoviesByCharacterId(
+    character_id: number,
+  ): Promise<Array<IMovie & { role_type?: string }>> {
+    const characterAppearancesRepository = getRepository(CharacterAppearance);
+    const appearances = await characterAppearancesRepository.find({
+      where: { character_id, movie_id: Not(IsNull()) },
+      relations: ['movie'],
+    });
+
+    return appearances.map(appearance => ({
+      ...appearance.movie,
+      role_type: appearance.role_type,
+    }));
+  }
+
+  public async findTVShowsByCharacterId(
+    character_id: number,
+  ): Promise<Array<ITVShow & { role_type?: string }>> {
+    const characterAppearancesRepository = getRepository(CharacterAppearance);
+    const appearances = await characterAppearancesRepository.find({
+      where: { character_id, tvshow_id: Not(IsNull()) },
+      relations: ['tvshow'],
+    });
+
+    return appearances.map(appearance => ({
+      ...appearance.tvshow,
       role_type: appearance.role_type,
     }));
   }

--- a/src/modules/characters/repositories/ICharactersRepository.ts
+++ b/src/modules/characters/repositories/ICharactersRepository.ts
@@ -1,3 +1,5 @@
+import IMovie from '@modules/movies/entities/IMovie';
+import ITVShow from '@modules/tvshows/entities/ITVShow';
 import ICharacter from '../entities/ICharacter';
 import ICreateCharacterDTO from '../dtos/ICreateCharacterDTO';
 import IFindAllCharactersDTO from '../dtos/IFindAllCharactersDTO';
@@ -10,5 +12,7 @@ export default interface ICharactersRepository {
   findAll(data: IFindAllCharactersDTO): Promise<IFindAllCharactersResponseDTO>;
   findByMovieId(movie_id: number): Promise<Array<ICharacter & { role_type?: string }>>;
   findByTVShowId(tvshow_id: number): Promise<Array<ICharacter & { role_type?: string }>>;
+  findMoviesByCharacterId(character_id: number): Promise<Array<IMovie & { role_type?: string }>>;
+  findTVShowsByCharacterId(character_id: number): Promise<Array<ITVShow & { role_type?: string }>>;
   delete(id: number): Promise<void>;
 }

--- a/src/modules/characters/repositories/fakes/FakeCharactersRepository.ts
+++ b/src/modules/characters/repositories/fakes/FakeCharactersRepository.ts
@@ -3,9 +3,24 @@ import ICharactersRepository from '@modules/characters/repositories/ICharactersR
 import ICreateCharacterDTO from '@modules/characters/dtos/ICreateCharacterDTO';
 import IFindAllCharactersDTO from '@modules/characters/dtos/IFindAllCharactersDTO';
 import IFindAllCharactersResponseDTO from '@modules/characters/dtos/IFindAllCharactersResponseDTO';
+import IMovie from '@modules/movies/entities/IMovie';
+import ITVShow from '@modules/tvshows/entities/ITVShow';
+
+interface IFakeAppearance {
+  character_id: number;
+  movie?: IMovie;
+  tvshow?: ITVShow;
+  role_type?: string;
+}
 
 class FakeCharactersRepository implements ICharactersRepository {
   private characters: ICharacter[] = [];
+
+  private appearances: IFakeAppearance[] = [];
+
+  public seedAppearance(appearance: IFakeAppearance): void {
+    this.appearances.push(appearance);
+  }
 
   public async create(data: ICreateCharacterDTO): Promise<ICharacter> {
     const character: ICharacter = {
@@ -102,6 +117,22 @@ class FakeCharactersRepository implements ICharactersRepository {
     return this.characters
       .filter(character => character.first_appearance_tvshow_id === tvshow_id)
       .map(character => ({ ...character, role_type: 'main' }));
+  }
+
+  public async findMoviesByCharacterId(
+    character_id: number,
+  ): Promise<Array<IMovie & { role_type?: string }>> {
+    return this.appearances
+      .filter(appearance => appearance.character_id === character_id && appearance.movie)
+      .map(appearance => ({ ...(appearance.movie as IMovie), role_type: appearance.role_type }));
+  }
+
+  public async findTVShowsByCharacterId(
+    character_id: number,
+  ): Promise<Array<ITVShow & { role_type?: string }>> {
+    return this.appearances
+      .filter(appearance => appearance.character_id === character_id && appearance.tvshow)
+      .map(appearance => ({ ...(appearance.tvshow as ITVShow), role_type: appearance.role_type }));
   }
 
 }

--- a/src/modules/characters/services/GetMoviesByCharacterService.spec.ts
+++ b/src/modules/characters/services/GetMoviesByCharacterService.spec.ts
@@ -1,0 +1,71 @@
+import AppError from '@shared/errors/AppError';
+import IMovie from '@modules/movies/entities/IMovie';
+import ITVShow from '@modules/tvshows/entities/ITVShow';
+import FakeCharactersRepository from '../repositories/fakes/FakeCharactersRepository';
+import GetMoviesByCharacterService from './GetMoviesByCharacterService';
+
+let fakeCharactersRepository: FakeCharactersRepository;
+let getMoviesByCharacter: GetMoviesByCharacterService;
+
+const movie = { id: 1, title: 'Iron Man', directed_by: 'Jon Favreau', post_credit_scenes: 1 } as IMovie;
+const tvshow = { id: 1, title: 'Loki', season: 1, number_episodes: 6 } as ITVShow;
+
+describe('GetMoviesByCharacter', () => {
+  beforeEach(() => {
+    fakeCharactersRepository = new FakeCharactersRepository();
+    getMoviesByCharacter = new GetMoviesByCharacterService(fakeCharactersRepository);
+  });
+
+  it('Should be able to get movies a character appears in, with role_type', async () => {
+    const character = await fakeCharactersRepository.create({
+      name: 'Tony Stark',
+      alias: 'Iron Man',
+      continuity: 'MCU',
+    });
+
+    fakeCharactersRepository.seedAppearance({
+      character_id: character.id,
+      movie,
+      role_type: 'main',
+    });
+
+    const result = await getMoviesByCharacter.execute(character.id);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe('Iron Man');
+    expect(result[0].role_type).toBe('main');
+  });
+
+  it('Should not include tvshow appearances', async () => {
+    const character = await fakeCharactersRepository.create({
+      name: 'Loki',
+      continuity: 'MCU',
+    });
+
+    fakeCharactersRepository.seedAppearance({
+      character_id: character.id,
+      tvshow,
+      role_type: 'main',
+    });
+
+    const result = await getMoviesByCharacter.execute(character.id);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('Should return empty array when the character has no movie appearances', async () => {
+    const character = await fakeCharactersRepository.create({
+      name: 'Pepper Potts',
+      continuity: 'MCU',
+    });
+
+    const result = await getMoviesByCharacter.execute(character.id);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('Should throw a 404 error when the character does not exist', async () => {
+    await expect(getMoviesByCharacter.execute(999)).rejects.toBeInstanceOf(AppError);
+    await expect(getMoviesByCharacter.execute(999)).rejects.toHaveProperty('statusCode', 404);
+  });
+});

--- a/src/modules/characters/services/GetMoviesByCharacterService.ts
+++ b/src/modules/characters/services/GetMoviesByCharacterService.ts
@@ -1,0 +1,24 @@
+import { injectable, inject } from 'tsyringe';
+import AppError from '@shared/errors/AppError';
+import IMovie from '@modules/movies/entities/IMovie';
+import ICharactersRepository from '../repositories/ICharactersRepository';
+
+@injectable()
+class GetMoviesByCharacterService {
+  constructor(
+    @inject('CharactersRepository')
+    private charactersRepository: ICharactersRepository,
+  ) {}
+
+  public async execute(character_id: number): Promise<Array<IMovie & { role_type?: string }>> {
+    const character = await this.charactersRepository.findById(character_id);
+
+    if (!character) {
+      throw new AppError('Character not found', 404);
+    }
+
+    return this.charactersRepository.findMoviesByCharacterId(character_id);
+  }
+}
+
+export default GetMoviesByCharacterService;

--- a/src/modules/characters/services/GetTVShowsByCharacterService.spec.ts
+++ b/src/modules/characters/services/GetTVShowsByCharacterService.spec.ts
@@ -1,0 +1,70 @@
+import AppError from '@shared/errors/AppError';
+import IMovie from '@modules/movies/entities/IMovie';
+import ITVShow from '@modules/tvshows/entities/ITVShow';
+import FakeCharactersRepository from '../repositories/fakes/FakeCharactersRepository';
+import GetTVShowsByCharacterService from './GetTVShowsByCharacterService';
+
+let fakeCharactersRepository: FakeCharactersRepository;
+let getTVShowsByCharacter: GetTVShowsByCharacterService;
+
+const movie = { id: 1, title: 'Thor: Ragnarok', directed_by: 'Taika Waititi', post_credit_scenes: 2 } as IMovie;
+const tvshow = { id: 1, title: 'Loki', season: 1, number_episodes: 6 } as ITVShow;
+
+describe('GetTVShowsByCharacter', () => {
+  beforeEach(() => {
+    fakeCharactersRepository = new FakeCharactersRepository();
+    getTVShowsByCharacter = new GetTVShowsByCharacterService(fakeCharactersRepository);
+  });
+
+  it('Should be able to get tv shows a character appears in, with role_type', async () => {
+    const character = await fakeCharactersRepository.create({
+      name: 'Loki',
+      continuity: 'MCU',
+    });
+
+    fakeCharactersRepository.seedAppearance({
+      character_id: character.id,
+      tvshow,
+      role_type: 'main',
+    });
+
+    const result = await getTVShowsByCharacter.execute(character.id);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe('Loki');
+    expect(result[0].role_type).toBe('main');
+  });
+
+  it('Should not include movie appearances', async () => {
+    const character = await fakeCharactersRepository.create({
+      name: 'Loki',
+      continuity: 'MCU',
+    });
+
+    fakeCharactersRepository.seedAppearance({
+      character_id: character.id,
+      movie,
+      role_type: 'supporting',
+    });
+
+    const result = await getTVShowsByCharacter.execute(character.id);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('Should return empty array when the character has no tv show appearances', async () => {
+    const character = await fakeCharactersRepository.create({
+      name: 'Happy Hogan',
+      continuity: 'MCU',
+    });
+
+    const result = await getTVShowsByCharacter.execute(character.id);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('Should throw a 404 error when the character does not exist', async () => {
+    await expect(getTVShowsByCharacter.execute(999)).rejects.toBeInstanceOf(AppError);
+    await expect(getTVShowsByCharacter.execute(999)).rejects.toHaveProperty('statusCode', 404);
+  });
+});

--- a/src/modules/characters/services/GetTVShowsByCharacterService.ts
+++ b/src/modules/characters/services/GetTVShowsByCharacterService.ts
@@ -1,0 +1,24 @@
+import { injectable, inject } from 'tsyringe';
+import AppError from '@shared/errors/AppError';
+import ITVShow from '@modules/tvshows/entities/ITVShow';
+import ICharactersRepository from '../repositories/ICharactersRepository';
+
+@injectable()
+class GetTVShowsByCharacterService {
+  constructor(
+    @inject('CharactersRepository')
+    private charactersRepository: ICharactersRepository,
+  ) {}
+
+  public async execute(character_id: number): Promise<Array<ITVShow & { role_type?: string }>> {
+    const character = await this.charactersRepository.findById(character_id);
+
+    if (!character) {
+      throw new AppError('Character not found', 404);
+    }
+
+    return this.charactersRepository.findTVShowsByCharacterId(character_id);
+  }
+}
+
+export default GetTVShowsByCharacterService;

--- a/src/modules/movies/infra/http/controllers/MoviesController.ts
+++ b/src/modules/movies/infra/http/controllers/MoviesController.ts
@@ -5,6 +5,11 @@ import CreateMovieService from '@modules/movies/services/CreateMovieService';
 import UpdateMovieService from '@modules/movies/services/UpdateMovieService';
 import ListAllMoviesService from '@modules/movies/services/ListAllMoviesService';
 import ShowMovieService from '@modules/movies/services/ShowMovieService';
+import {
+  presentMovie,
+  presentMovieCollection,
+} from '@modules/movies/infra/http/presenters/MoviePresenter';
+import { getBaseUrl } from '@shared/infra/http/hateoas';
 
 interface IRequestQuery {
   page?: number;
@@ -45,7 +50,17 @@ export default class MoviesController {
       is_mcu: is_mcu === 'true' ? true : is_mcu === 'false' ? false : undefined,
     });
 
-    return response.status(200).json({ data, total });
+    return response.status(200).json(
+      presentMovieCollection({
+        data,
+        total,
+        page,
+        limit,
+        baseUrl: getBaseUrl(request),
+        path: request.baseUrl + request.path,
+        query: request.query,
+      }),
+    );
   }
 
   public async create(request: Request, response: Response): Promise<Response> {
@@ -80,6 +95,6 @@ export default class MoviesController {
       return response.status(404).json({ message: 'Movie not found' });
     }
 
-    return response.status(200).json(movie);
+    return response.status(200).json(presentMovie(movie, getBaseUrl(request)));
   }
 }

--- a/src/modules/movies/infra/http/presenters/MoviePresenter.spec.ts
+++ b/src/modules/movies/infra/http/presenters/MoviePresenter.spec.ts
@@ -1,0 +1,63 @@
+import IMovie from '@modules/movies/entities/IMovie';
+import { presentMovie, presentMovieCollection } from './MoviePresenter';
+
+const baseUrl = 'http://localhost:3333';
+
+const movie = {
+  id: 1,
+  title: 'Iron Man',
+  directed_by: 'Jon Favreau',
+  post_credit_scenes: 1,
+} as IMovie;
+
+describe('MoviePresenter', () => {
+  it('Should add self and characters links', () => {
+    const presented = presentMovie(movie, baseUrl);
+
+    expect(presented._links.self).toEqual({ href: `${baseUrl}/api/v1/movies/1` });
+    expect(presented._links.characters).toEqual({ href: `${baseUrl}/api/v1/characters/movie/1` });
+    expect(presented.title).toBe('Iron Man');
+  });
+
+  it('Should omit related_movies link when the relation is not loaded', () => {
+    const presented = presentMovie(movie, baseUrl);
+
+    expect(presented._links.related_movies).toBeUndefined();
+  });
+
+  it('Should link related_movies and add self links to embedded items when loaded', () => {
+    const related = { id: 2, title: 'Iron Man 2' } as IMovie;
+    const presented = presentMovie({ ...movie, related_movies: [related] }, baseUrl);
+
+    expect(presented._links.related_movies).toEqual([{ href: `${baseUrl}/api/v1/movies/2` }]);
+    expect(presented.related_movies?.[0]).toMatchObject({
+      id: 2,
+      _links: { self: { href: `${baseUrl}/api/v1/movies/2` } },
+    });
+  });
+
+  it('Should skip id-dependent links when id is missing (columns selection)', () => {
+    const presented = presentMovie({ title: 'Iron Man' } as IMovie, baseUrl);
+
+    expect(presented._links).toEqual({});
+  });
+
+  it('Should wrap collections with pagination metadata and links', () => {
+    const collection = presentMovieCollection({
+      data: [movie],
+      total: 12,
+      page: '2',
+      limit: '5',
+      baseUrl,
+      path: '/api/v1/movies',
+      query: { page: '2', limit: '5' },
+    });
+
+    expect(collection.total).toBe(12);
+    expect(collection.page).toBe(2);
+    expect(collection.limit).toBe(5);
+    expect(collection.data[0]._links.self).toEqual({ href: `${baseUrl}/api/v1/movies/1` });
+    expect(collection._links.next).toEqual({ href: `${baseUrl}/api/v1/movies?limit=5&page=3` });
+    expect(collection._links.prev).toEqual({ href: `${baseUrl}/api/v1/movies?limit=5&page=1` });
+  });
+});

--- a/src/modules/movies/infra/http/presenters/MoviePresenter.ts
+++ b/src/modules/movies/infra/http/presenters/MoviePresenter.ts
@@ -1,0 +1,62 @@
+import IMovie from '@modules/movies/entities/IMovie';
+import {
+  ILink,
+  IResourceLinks,
+  WithLinks,
+  buildPaginationLinks,
+} from '@shared/infra/http/hateoas';
+
+interface IPresentMovieCollectionParams {
+  data: IMovie[];
+  total: number;
+  page?: number | string;
+  limit?: number | string;
+  baseUrl: string;
+  path: string;
+  query: Record<string, unknown>;
+}
+
+export function presentMovie(movie: IMovie, baseUrl: string): WithLinks<IMovie> {
+  const _links: IResourceLinks = {};
+
+  if (movie.id != null) {
+    _links.self = { href: `${baseUrl}/api/v1/movies/${movie.id}` };
+    _links.characters = { href: `${baseUrl}/api/v1/characters/movie/${movie.id}` };
+  }
+
+  let related_movies = movie.related_movies;
+
+  if (Array.isArray(related_movies)) {
+    _links.related_movies = related_movies
+      .filter(related => related.id != null)
+      .map<ILink>(related => ({ href: `${baseUrl}/api/v1/movies/${related.id}` }));
+
+    related_movies = related_movies.map(related => ({
+      ...related,
+      _links: related.id != null
+        ? { self: { href: `${baseUrl}/api/v1/movies/${related.id}` } }
+        : {},
+    }));
+  }
+
+  return { ...movie, ...(related_movies && { related_movies }), _links };
+}
+
+export function presentMovieCollection({
+  data,
+  total,
+  page,
+  limit,
+  baseUrl,
+  path,
+  query,
+}: IPresentMovieCollectionParams) {
+  const { _links, meta } = buildPaginationLinks({ baseUrl, path, query, page, limit, total });
+
+  return {
+    data: data.map(movie => presentMovie(movie, baseUrl)),
+    total,
+    ...meta,
+    _links,
+  };
+}

--- a/src/modules/timeline/infra/http/controllers/TimelineController.ts
+++ b/src/modules/timeline/infra/http/controllers/TimelineController.ts
@@ -2,6 +2,8 @@ import { Request, Response } from 'express';
 import { container } from 'tsyringe';
 
 import GetTimelineService from '@modules/timeline/services/GetTimelineService';
+import { presentTimeline } from '@modules/timeline/infra/http/presenters/TimelinePresenter';
+import { getBaseUrl } from '@shared/infra/http/hateoas';
 
 interface IRequestQuery {
   multiverse?: string;
@@ -14,6 +16,6 @@ export default class TimelineController {
     const getTimeline = container.resolve(GetTimelineService);
     const timeline = await getTimeline.execute(multiverse);
 
-    return response.status(200).json(timeline);
+    return response.status(200).json(presentTimeline(timeline, getBaseUrl(request)));
   }
 } 

--- a/src/modules/timeline/infra/http/presenters/TimelinePresenter.spec.ts
+++ b/src/modules/timeline/infra/http/presenters/TimelinePresenter.spec.ts
@@ -1,0 +1,38 @@
+import { presentTimeline } from './TimelinePresenter';
+
+const baseUrl = 'http://localhost:3333';
+
+describe('TimelinePresenter', () => {
+  it('Should link entries to movies or tvshows based on type', () => {
+    const timeline = [
+      {
+        continuity: 'MCU',
+        multiverse_designation: 'Earth-616',
+        entries: [
+          { id: 1, title: 'Iron Man', chronology_order: 3, type: 'movie' },
+          { id: 2, title: 'Loki', chronology_order: 5, type: 'tvshow' },
+        ],
+      },
+    ];
+
+    const presented = presentTimeline(timeline, baseUrl);
+
+    expect(presented[0].continuity).toBe('MCU');
+    expect(presented[0].entries[0]._links.self).toEqual({ href: `${baseUrl}/api/v1/movies/1` });
+    expect(presented[0].entries[1]._links.self).toEqual({ href: `${baseUrl}/api/v1/tvshows/2` });
+  });
+
+  it('Should default unknown types to movie links', () => {
+    const timeline = [
+      {
+        continuity: 'MCU',
+        multiverse_designation: 'Earth-616',
+        entries: [{ id: 4, title: 'One-Shot', chronology_order: 1, type: 'one-shot' }],
+      },
+    ];
+
+    const presented = presentTimeline(timeline, baseUrl);
+
+    expect(presented[0].entries[0]._links.self).toEqual({ href: `${baseUrl}/api/v1/movies/4` });
+  });
+});

--- a/src/modules/timeline/infra/http/presenters/TimelinePresenter.ts
+++ b/src/modules/timeline/infra/http/presenters/TimelinePresenter.ts
@@ -1,0 +1,36 @@
+import { IResourceLinks } from '@shared/infra/http/hateoas';
+
+interface ITimelineEntry {
+  id: number;
+  title: string;
+  chronology_order: number;
+  type: string;
+}
+
+interface ITimelineContinuity {
+  continuity: string;
+  multiverse_designation: string;
+  entries: ITimelineEntry[];
+}
+
+type ITimelineEntryWithLinks = ITimelineEntry & { _links: IResourceLinks };
+
+export function presentTimeline(
+  timeline: ITimelineContinuity[],
+  baseUrl: string,
+): Array<ITimelineContinuity & { entries: ITimelineEntryWithLinks[] }> {
+  return timeline.map(continuity => ({
+    ...continuity,
+    entries: continuity.entries.map(entry => ({
+      ...entry,
+      _links: {
+        self: {
+          href:
+            entry.type === 'tvshow'
+              ? `${baseUrl}/api/v1/tvshows/${entry.id}`
+              : `${baseUrl}/api/v1/movies/${entry.id}`,
+        },
+      },
+    })),
+  }));
+}

--- a/src/modules/tvshows/infra/http/controllers/TVShowsController.ts
+++ b/src/modules/tvshows/infra/http/controllers/TVShowsController.ts
@@ -2,6 +2,11 @@ import { container } from 'tsyringe';
 import { Request, Response } from 'express';
 import ListTVShowsService from '@modules/tvshows/services/ListTVShowsService';
 import ShowTVShowService from '@modules/tvshows/services/ShowTVShowService';
+import {
+  presentTVShow,
+  presentTVShowCollection,
+} from '@modules/tvshows/infra/http/presenters/TVShowPresenter';
+import { getBaseUrl } from '@shared/infra/http/hateoas';
 
 interface IRequestQuery {
   page?: number;
@@ -42,7 +47,17 @@ export default class TVShowsController {
       is_mcu: is_mcu === 'true' ? true : is_mcu === 'false' ? false : undefined,
     });
 
-    return response.status(200).json({ data, total });
+    return response.status(200).json(
+      presentTVShowCollection({
+        data,
+        total,
+        page,
+        limit,
+        baseUrl: getBaseUrl(request),
+        path: request.baseUrl + request.path,
+        query: request.query,
+      }),
+    );
   }
 
   public async show(request: Request, response: Response): Promise<Response> {
@@ -54,6 +69,6 @@ export default class TVShowsController {
       return response.status(404).json({ message: 'TV Show not found' });
     }
 
-    return response.status(200).json(tvshow);
+    return response.status(200).json(presentTVShow(tvshow, getBaseUrl(request)));
   }
 }

--- a/src/modules/tvshows/infra/http/presenters/TVShowPresenter.spec.ts
+++ b/src/modules/tvshows/infra/http/presenters/TVShowPresenter.spec.ts
@@ -1,0 +1,42 @@
+import ITVShow from '@modules/tvshows/entities/ITVShow';
+import { presentTVShow, presentTVShowCollection } from './TVShowPresenter';
+
+const baseUrl = 'http://localhost:3333';
+
+const tvshow = {
+  id: 3,
+  title: 'Loki',
+  season: 1,
+  number_episodes: 6,
+} as ITVShow;
+
+describe('TVShowPresenter', () => {
+  it('Should add self and characters links', () => {
+    const presented = presentTVShow(tvshow, baseUrl);
+
+    expect(presented._links.self).toEqual({ href: `${baseUrl}/api/v1/tvshows/3` });
+    expect(presented._links.characters).toEqual({ href: `${baseUrl}/api/v1/characters/tvshow/3` });
+    expect(presented.title).toBe('Loki');
+  });
+
+  it('Should skip links when id is missing (columns selection)', () => {
+    const presented = presentTVShow({ title: 'Loki' } as ITVShow, baseUrl);
+
+    expect(presented._links).toEqual({});
+  });
+
+  it('Should wrap collections with pagination metadata and links', () => {
+    const collection = presentTVShowCollection({
+      data: [tvshow],
+      total: 1,
+      baseUrl,
+      path: '/api/v1/tvshows',
+      query: {},
+    });
+
+    expect(collection.total).toBe(1);
+    expect(collection.page).toBe(1);
+    expect(collection._links.self).toEqual({ href: `${baseUrl}/api/v1/tvshows` });
+    expect(collection.data[0]._links.self).toEqual({ href: `${baseUrl}/api/v1/tvshows/3` });
+  });
+});

--- a/src/modules/tvshows/infra/http/presenters/TVShowPresenter.ts
+++ b/src/modules/tvshows/infra/http/presenters/TVShowPresenter.ts
@@ -1,0 +1,46 @@
+import ITVShow from '@modules/tvshows/entities/ITVShow';
+import {
+  IResourceLinks,
+  WithLinks,
+  buildPaginationLinks,
+} from '@shared/infra/http/hateoas';
+
+interface IPresentTVShowCollectionParams {
+  data: ITVShow[];
+  total: number;
+  page?: number | string;
+  limit?: number | string;
+  baseUrl: string;
+  path: string;
+  query: Record<string, unknown>;
+}
+
+export function presentTVShow(tvshow: ITVShow, baseUrl: string): WithLinks<ITVShow> {
+  const _links: IResourceLinks = {};
+
+  if (tvshow.id != null) {
+    _links.self = { href: `${baseUrl}/api/v1/tvshows/${tvshow.id}` };
+    _links.characters = { href: `${baseUrl}/api/v1/characters/tvshow/${tvshow.id}` };
+  }
+
+  return { ...tvshow, _links };
+}
+
+export function presentTVShowCollection({
+  data,
+  total,
+  page,
+  limit,
+  baseUrl,
+  path,
+  query,
+}: IPresentTVShowCollectionParams) {
+  const { _links, meta } = buildPaginationLinks({ baseUrl, path, query, page, limit, total });
+
+  return {
+    data: data.map(tvshow => presentTVShow(tvshow, baseUrl)),
+    total,
+    ...meta,
+    _links,
+  };
+}

--- a/src/shared/infra/http/hateoas/buildPaginationLinks.spec.ts
+++ b/src/shared/infra/http/hateoas/buildPaginationLinks.spec.ts
@@ -1,0 +1,108 @@
+import buildPaginationLinks from './buildPaginationLinks';
+
+const baseUrl = 'http://localhost:3333';
+const path = '/api/v1/movies';
+
+describe('buildPaginationLinks', () => {
+  it('Should return only self and first links when limit is absent', () => {
+    const { _links, meta } = buildPaginationLinks({
+      baseUrl,
+      path,
+      query: {},
+      total: 40,
+    });
+
+    expect(_links.self).toEqual({ href: 'http://localhost:3333/api/v1/movies' });
+    expect(_links.first).toEqual(_links.self);
+    expect(_links.next).toBeUndefined();
+    expect(_links.prev).toBeUndefined();
+    expect(_links.last).toBeUndefined();
+    expect(meta).toEqual({ page: 1 });
+  });
+
+  it('Should build first, last and next links on the first page', () => {
+    const { _links, meta } = buildPaginationLinks({
+      baseUrl,
+      path,
+      query: { limit: '5' },
+      limit: '5',
+      total: 12,
+    });
+
+    expect(_links.self).toEqual({ href: `${baseUrl}${path}?limit=5&page=1` });
+    expect(_links.first).toEqual({ href: `${baseUrl}${path}?limit=5&page=1` });
+    expect(_links.last).toEqual({ href: `${baseUrl}${path}?limit=5&page=3` });
+    expect(_links.next).toEqual({ href: `${baseUrl}${path}?limit=5&page=2` });
+    expect(_links.prev).toBeUndefined();
+    expect(meta).toEqual({ page: 1, limit: 5 });
+  });
+
+  it('Should build prev and next links on a middle page', () => {
+    const { _links } = buildPaginationLinks({
+      baseUrl,
+      path,
+      query: { page: '2', limit: '5' },
+      page: '2',
+      limit: '5',
+      total: 12,
+    });
+
+    expect(_links.prev).toEqual({ href: `${baseUrl}${path}?limit=5&page=1` });
+    expect(_links.next).toEqual({ href: `${baseUrl}${path}?limit=5&page=3` });
+  });
+
+  it('Should omit next on the last page', () => {
+    const { _links } = buildPaginationLinks({
+      baseUrl,
+      path,
+      query: { page: '3', limit: '5' },
+      page: '3',
+      limit: '5',
+      total: 12,
+    });
+
+    expect(_links.next).toBeUndefined();
+    expect(_links.prev).toEqual({ href: `${baseUrl}${path}?limit=5&page=2` });
+  });
+
+  it('Should preserve other query params in every link', () => {
+    const { _links } = buildPaginationLinks({
+      baseUrl,
+      path,
+      query: { page: '2', limit: '5', order: 'release_date,DESC', studio: 'Marvel Studios' },
+      page: '2',
+      limit: '5',
+      total: 20,
+    });
+
+    const next = (_links.next as { href: string }).href;
+
+    expect(next).toContain('order=release_date%2CDESC');
+    expect(next).toContain('studio=Marvel+Studios');
+    expect(next).toContain('page=3');
+  });
+
+  it('Should strip the trailing slash from the router-root path', () => {
+    const { _links } = buildPaginationLinks({
+      baseUrl,
+      path: '/api/v1/movies/',
+      query: {},
+      total: 3,
+    });
+
+    expect(_links.self).toEqual({ href: `${baseUrl}/api/v1/movies` });
+  });
+
+  it('Should point last to page 1 when there are no rows', () => {
+    const { _links } = buildPaginationLinks({
+      baseUrl,
+      path,
+      query: { limit: '5' },
+      limit: '5',
+      total: 0,
+    });
+
+    expect(_links.last).toEqual({ href: `${baseUrl}${path}?limit=5&page=1` });
+    expect(_links.next).toBeUndefined();
+  });
+});

--- a/src/shared/infra/http/hateoas/buildPaginationLinks.ts
+++ b/src/shared/infra/http/hateoas/buildPaginationLinks.ts
@@ -1,0 +1,82 @@
+import { IResourceLinks } from './types';
+
+interface IBuildPaginationLinksParams {
+  baseUrl: string;
+  path: string;
+  query: Record<string, unknown>;
+  page?: number | string;
+  limit?: number | string;
+  total: number;
+}
+
+interface IBuildPaginationLinksResult {
+  _links: IResourceLinks;
+  meta: { page: number; limit?: number };
+}
+
+function buildUrl(
+  baseUrl: string,
+  path: string,
+  query: Record<string, unknown>,
+  page?: number,
+): string {
+  const normalizedPath = path.length > 1 ? path.replace(/\/+$/, '') : path;
+  const params = new URLSearchParams();
+
+  Object.keys(query)
+    .sort()
+    .forEach(key => {
+      if (key === 'page') return;
+      const value = query[key];
+      if (value !== undefined && value !== null) {
+        params.set(key, String(value));
+      }
+    });
+
+  if (page !== undefined) {
+    params.set('page', String(page));
+  }
+
+  const queryString = params.toString();
+
+  return `${baseUrl}${normalizedPath}${queryString ? `?${queryString}` : ''}`;
+}
+
+export default function buildPaginationLinks({
+  baseUrl,
+  path,
+  query,
+  page,
+  limit,
+  total,
+}: IBuildPaginationLinksParams): IBuildPaginationLinksResult {
+  const currentPage = Number(page) || 1;
+  const perPage = Number(limit) || undefined;
+
+  if (!perPage) {
+    const self = buildUrl(baseUrl, path, query);
+
+    return {
+      _links: { self: { href: self }, first: { href: self } },
+      meta: { page: 1 },
+    };
+  }
+
+  const lastPage = Math.max(1, Math.ceil(total / perPage));
+
+  const _links: IResourceLinks = {
+    self: { href: buildUrl(baseUrl, path, query, currentPage) },
+    first: { href: buildUrl(baseUrl, path, query, 1) },
+    last: { href: buildUrl(baseUrl, path, query, lastPage) },
+  };
+
+  if (currentPage > 1) {
+    _links.prev = { href: buildUrl(baseUrl, path, query, currentPage - 1) };
+  }
+
+  if (currentPage * perPage < total) {
+    _links.next = { href: buildUrl(baseUrl, path, query, currentPage + 1) };
+  }
+
+  return { _links, meta: { page: currentPage, limit: perPage } };
+}

--- a/src/shared/infra/http/hateoas/getBaseUrl.spec.ts
+++ b/src/shared/infra/http/hateoas/getBaseUrl.spec.ts
@@ -1,0 +1,45 @@
+import { Request } from 'express';
+import getBaseUrl from './getBaseUrl';
+
+function makeRequest(protocol: string, host: string): Request {
+  return {
+    protocol,
+    get: (header: string) => (header === 'host' ? host : undefined),
+  } as unknown as Request;
+}
+
+describe('getBaseUrl', () => {
+  const originalAppUrl = process.env.APP_URL;
+
+  afterEach(() => {
+    if (originalAppUrl === undefined) {
+      delete process.env.APP_URL;
+    } else {
+      process.env.APP_URL = originalAppUrl;
+    }
+  });
+
+  it('Should build the base URL from the request when APP_URL is not set', () => {
+    delete process.env.APP_URL;
+
+    const baseUrl = getBaseUrl(makeRequest('http', 'localhost:3333'));
+
+    expect(baseUrl).toBe('http://localhost:3333');
+  });
+
+  it('Should prefer APP_URL over the request host', () => {
+    process.env.APP_URL = 'https://mcuapi.example.com';
+
+    const baseUrl = getBaseUrl(makeRequest('http', 'localhost:3333'));
+
+    expect(baseUrl).toBe('https://mcuapi.example.com');
+  });
+
+  it('Should strip trailing slashes from APP_URL', () => {
+    process.env.APP_URL = 'https://mcuapi.example.com/';
+
+    const baseUrl = getBaseUrl(makeRequest('http', 'localhost:3333'));
+
+    expect(baseUrl).toBe('https://mcuapi.example.com');
+  });
+});

--- a/src/shared/infra/http/hateoas/getBaseUrl.ts
+++ b/src/shared/infra/http/hateoas/getBaseUrl.ts
@@ -1,0 +1,11 @@
+import { Request } from 'express';
+
+export default function getBaseUrl(request: Request): string {
+  const appUrl = process.env.APP_URL;
+
+  if (appUrl) {
+    return appUrl.replace(/\/+$/, '');
+  }
+
+  return `${request.protocol}://${request.get('host')}`;
+}

--- a/src/shared/infra/http/hateoas/index.ts
+++ b/src/shared/infra/http/hateoas/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export { default as getBaseUrl } from './getBaseUrl';
+export { default as buildPaginationLinks } from './buildPaginationLinks';

--- a/src/shared/infra/http/hateoas/types.ts
+++ b/src/shared/infra/http/hateoas/types.ts
@@ -1,0 +1,11 @@
+export interface ILink {
+  href: string;
+}
+
+export type TLinkValue = ILink | ILink[];
+
+export interface IResourceLinks {
+  [rel: string]: TLinkValue;
+}
+
+export type WithLinks<T> = T & { _links: IResourceLinks };

--- a/src/shared/infra/http/server.ts
+++ b/src/shared/infra/http/server.ts
@@ -13,6 +13,8 @@ import '@shared/container';
 
 const app = express();
 
+app.set('trust proxy', 1);
+
 app.use(cors());
 app.use(express.json() as express.RequestHandler);
 app.use('/docs', swaggerUI.serve, swaggerUI.setup(swaggerFile));


### PR DESCRIPTION
## Summary
- Adds HAL-style `_links` to every resource and collection response (Movie, TVShow, Character, Timeline entries) — `self`, relationship links (e.g. `characters`, `related_movies`, `variant_of`, `first_appearance_movie/tvshow`), and collection `self/first/last/prev/next` with all query params preserved.
- Adds pagination metadata (`page`, `limit`) to `GET /movies`, `/tvshows`, `/characters`.
- Adds two new endpoints, `GET /characters/:id/movies` and `GET /characters/:id/tvshows`, so a character's appearances are navigable (previously only movies/tvshows linked to their characters, not the reverse).
- Absolute link URLs are built from the request host by default, or from the optional `APP_URL` env var (useful behind Railway's proxy — `trust proxy` is now enabled).
- Strictly additive: existing fields/shapes (`data`/`total`, bare arrays, entity fields) are unchanged.
- Updates `swagger.json`, README, and SETUP.md accordingly.

## Test plan
- [x] `npm test` — 65 tests passing (17 new specs: services, presenters, hateoas helpers)
- [x] `tsc --noEmit` — clean
- [x] Verified end-to-end against a real Postgres instance: pagination links/meta, `related_movies`/`characters` links, null-FK omission on characters, new appearance endpoints incl. 404 for unknown character, timeline entry links, `columns=` graceful degradation, `APP_URL` override, `/docs` still renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)