### PR TITLE
fix(hateoas): stop embedding full relation data, links-only across the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ ___
 
 ## 💥 Changelogs <a name="changelogs"></a>
 <details>
+  <summary>2026-07-23: Movies | Characters — HATEOAS relations are now links-only (breaking)</summary>
+
+  - CHANGED
+    - *`GET /movies/{id}` no longer embeds full `related_movies` objects — only `_links.related_movies` hrefs are returned*
+    - *`GET /characters/{id}` no longer embeds `variant_character`, `first_appearance_movie` or `first_appearance_tvshow` objects — only their `_links` hrefs (`variant_of`, `first_appearance_movie`, `first_appearance_tvshow`) are returned*
+    - *This is a breaking change to the response shape, made to keep the API consistently HATEOAS/HAL-style (links only, no embedded resource bodies)*
+</details>
+
+<details>
   <summary>2026-04-10: Movies | TV Shows — added updated_at field</summary>
 
   - ADDED

--- a/src/config/swagger.json
+++ b/src/config/swagger.json
@@ -179,22 +179,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/Movie"
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "related_movies": {
-                          "type": "array",
-                          "items": {
-                            "$ref": "#/components/schemas/Movie"
-                          }
-                        }
-                      }
-                    }
-                  ]
+                  "$ref": "#/components/schemas/Movie"
                 }
               }
             }

--- a/src/modules/characters/infra/http/presenters/CharacterPresenter.spec.ts
+++ b/src/modules/characters/infra/http/presenters/CharacterPresenter.spec.ts
@@ -1,5 +1,4 @@
 import ICharacter from '@modules/characters/entities/ICharacter';
-import IMovie from '@modules/movies/entities/IMovie';
 import { presentCharacter, presentCharacterArray } from './CharacterPresenter';
 
 const baseUrl = 'http://localhost:3333';
@@ -43,20 +42,27 @@ describe('CharacterPresenter', () => {
     expect(presented._links.first_appearance_tvshow).toEqual({ href: `${baseUrl}/api/v1/tvshows/9` });
   });
 
-  it('Should add self-only links to embedded relation objects', () => {
-    const presented = presentCharacter(
-      {
-        ...character,
-        first_appearance_movie_id: 5,
-        first_appearance_movie: { id: 5, title: 'Thor' } as IMovie,
-      },
-      baseUrl,
-    );
+  it('Should not embed relation objects, even when present on the input', () => {
+    const characterWithLoadedRelations = {
+      ...character,
+      variant_of: 3,
+      first_appearance_movie_id: 5,
+      first_appearance_tvshow_id: 9,
+      variant_character: { id: 3, name: 'Loki Variant' },
+      first_appearance_movie: { id: 5, title: 'Thor' },
+      first_appearance_tvshow: { id: 9, title: 'Loki' },
+    };
 
-    expect(presented.first_appearance_movie).toMatchObject({
-      id: 5,
-      _links: { self: { href: `${baseUrl}/api/v1/movies/5` } },
-    });
+    const presented = presentCharacter(characterWithLoadedRelations, baseUrl);
+
+    const presentedAsRecord = presented as unknown as Record<string, unknown>;
+
+    expect(presentedAsRecord.variant_character).toBeUndefined();
+    expect(presentedAsRecord.first_appearance_movie).toBeUndefined();
+    expect(presentedAsRecord.first_appearance_tvshow).toBeUndefined();
+    expect(presented._links.variant_of).toEqual({ href: `${baseUrl}/api/v1/characters/3` });
+    expect(presented._links.first_appearance_movie).toEqual({ href: `${baseUrl}/api/v1/movies/5` });
+    expect(presented._links.first_appearance_tvshow).toEqual({ href: `${baseUrl}/api/v1/tvshows/9` });
   });
 
   it('Should preserve role_type on array items', () => {

--- a/src/modules/characters/infra/http/presenters/CharacterPresenter.ts
+++ b/src/modules/characters/infra/http/presenters/CharacterPresenter.ts
@@ -1,6 +1,4 @@
 import ICharacter from '@modules/characters/entities/ICharacter';
-import IMovie from '@modules/movies/entities/IMovie';
-import ITVShow from '@modules/tvshows/entities/ITVShow';
 import {
   IResourceLinks,
   WithLinks,
@@ -8,10 +6,10 @@ import {
 } from '@shared/infra/http/hateoas';
 
 type ICharacterWithRelations = ICharacter & {
-  variant_character?: ICharacter;
-  first_appearance_movie?: IMovie;
-  first_appearance_tvshow?: ITVShow;
   role_type?: string;
+  variant_character?: unknown;
+  first_appearance_movie?: unknown;
+  first_appearance_tvshow?: unknown;
 };
 
 interface IPresentCharacterCollectionParams {
@@ -22,18 +20,6 @@ interface IPresentCharacterCollectionParams {
   baseUrl: string;
   path: string;
   query: Record<string, unknown>;
-}
-
-function withSelfLink<T extends { id?: number }>(
-  entity: T | undefined,
-  selfHref: (id: number) => string,
-): (T & { _links: IResourceLinks }) | undefined {
-  if (!entity) return undefined;
-
-  return {
-    ...entity,
-    _links: entity.id != null ? { self: { href: selfHref(entity.id) } } : {},
-  };
 }
 
 export function presentCharacter(
@@ -64,24 +50,13 @@ export function presentCharacter(
     };
   }
 
-  const variant_character = withSelfLink(
-    character.variant_character,
-    id => `${baseUrl}/api/v1/characters/${id}`,
-  );
-  const first_appearance_movie = withSelfLink(
-    character.first_appearance_movie,
-    id => `${baseUrl}/api/v1/movies/${id}`,
-  );
-  const first_appearance_tvshow = withSelfLink(
-    character.first_appearance_tvshow,
-    id => `${baseUrl}/api/v1/tvshows/${id}`,
-  );
+  const characterWithoutEmbeddedRelations: ICharacterWithRelations = { ...character };
+  delete characterWithoutEmbeddedRelations.variant_character;
+  delete characterWithoutEmbeddedRelations.first_appearance_movie;
+  delete characterWithoutEmbeddedRelations.first_appearance_tvshow;
 
   return {
-    ...character,
-    ...(variant_character && { variant_character }),
-    ...(first_appearance_movie && { first_appearance_movie }),
-    ...(first_appearance_tvshow && { first_appearance_tvshow }),
+    ...characterWithoutEmbeddedRelations,
     _links,
   };
 }

--- a/src/modules/characters/infra/typeorm/repositories/CharactersRepository.ts
+++ b/src/modules/characters/infra/typeorm/repositories/CharactersRepository.ts
@@ -29,9 +29,7 @@ class CharactersRepository implements ICharactersRepository {
   }
 
   public async findById(id: number): Promise<Character | undefined> {
-    const findCharacter = await this.ormRepository.findOne(id, {
-      relations: ['variant_character', 'first_appearance_movie', 'first_appearance_tvshow'],
-    });
+    const findCharacter = await this.ormRepository.findOne(id);
 
     return findCharacter;
   }
@@ -91,7 +89,6 @@ class CharactersRepository implements ICharactersRepository {
       ...(columnOrder && {
         order: { [columnOrder]: sortingOrder.toUpperCase() },
       }),
-      relations: ['variant_character', 'first_appearance_movie', 'first_appearance_tvshow'],
     });
 
     return { data: characters, total };

--- a/src/modules/movies/infra/http/presenters/MoviePresenter.spec.ts
+++ b/src/modules/movies/infra/http/presenters/MoviePresenter.spec.ts
@@ -25,15 +25,12 @@ describe('MoviePresenter', () => {
     expect(presented._links.related_movies).toBeUndefined();
   });
 
-  it('Should link related_movies and add self links to embedded items when loaded', () => {
+  it('Should link related_movies without embedding the full related movie data', () => {
     const related = { id: 2, title: 'Iron Man 2' } as IMovie;
     const presented = presentMovie({ ...movie, related_movies: [related] }, baseUrl);
 
     expect(presented._links.related_movies).toEqual([{ href: `${baseUrl}/api/v1/movies/2` }]);
-    expect(presented.related_movies?.[0]).toMatchObject({
-      id: 2,
-      _links: { self: { href: `${baseUrl}/api/v1/movies/2` } },
-    });
+    expect(presented.related_movies).toBeUndefined();
   });
 
   it('Should skip id-dependent links when id is missing (columns selection)', () => {

--- a/src/modules/movies/infra/http/presenters/MoviePresenter.ts
+++ b/src/modules/movies/infra/http/presenters/MoviePresenter.ts
@@ -24,22 +24,15 @@ export function presentMovie(movie: IMovie, baseUrl: string): WithLinks<IMovie> 
     _links.characters = { href: `${baseUrl}/api/v1/characters/movie/${movie.id}` };
   }
 
-  let related_movies = movie.related_movies;
+  const { related_movies, ...movieWithoutRelatedMovies } = movie;
 
   if (Array.isArray(related_movies)) {
     _links.related_movies = related_movies
       .filter(related => related.id != null)
       .map<ILink>(related => ({ href: `${baseUrl}/api/v1/movies/${related.id}` }));
-
-    related_movies = related_movies.map(related => ({
-      ...related,
-      _links: related.id != null
-        ? { self: { href: `${baseUrl}/api/v1/movies/${related.id}` } }
-        : {},
-    }));
   }
 
-  return { ...movie, ...(related_movies && { related_movies }), _links };
+  return { ...movieWithoutRelatedMovies, _links };
 }
 
 export function presentMovieCollection({


### PR DESCRIPTION
## Summary

- `MoviePresenter.presentMovie` no longer re-embeds `related_movies` with full movie data; only `_links.related_movies` hrefs remain.
- `CharacterPresenter.presentCharacter` no longer embeds `variant_character`, `first_appearance_movie`, or `first_appearance_tvshow`; only the corresponding FK-based `_links` entries remain (and are now defensively stripped even if present on the input).
- `CharactersRepository.findById` / `findAll` no longer eager-load `variant_character`, `first_appearance_movie`, `first_appearance_tvshow` — those relations were only ever used to feed the now-removed embedding. `MoviesRepository.findById` still loads `related_movies` since the ids are needed to build the `_links.related_movies` hrefs.
- README changelog updated to flag this as a breaking response-shape change.

Closes #39

## Test plan

- [x] Unit tests pass (`npm test`)
- [x] Type check passes (`npx tsc --noEmit`)
- [x] Build passes (`npm run build`)
- [ ] Manual check: `GET /api/v1/movies/:id` no longer includes a `related_movies` field
- [ ] Manual check: `GET /api/v1/characters/:id` no longer includes `variant_character` / `first_appearance_movie` / `first_appearance_tvshow` fields

🤖 Generated with [Claude Code](https://claude.ai/claude-code)