### PR TITLE
feat: add related-content connection between movies and tvshows

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -126,6 +126,7 @@ Restart Claude Code — the MCP server activates automatically when you open thi
 | `update_character` | Update a character by ID |
 | `delete_character` | Delete a character by ID |
 | `link_appearance` | Link a character to a movie or TV show |
+| `link_related_content` | Link a movie to a TV show as related content |
 | `bulk_import_characters` | Import multiple characters from a JSON array |
 | `get_timeline` | View the chronological timeline, optionally filtered by Earth |
 

--- a/mcuapi-mcp/src/index.ts
+++ b/mcuapi-mcp/src/index.ts
@@ -636,6 +636,71 @@ server.registerTool(
   },
 );
 
+server.registerTool(
+  'link_related_content',
+  {
+    description: 'Link a movie to a TV show as related/tie-in content (bidirectional).',
+    inputSchema: {
+      movie_id: z.number().int(),
+      tvshow_id: z.number().int(),
+    },
+  },
+  async ({ movie_id, tvshow_id }) => {
+    const [movie] = await query<{ id: number; title: string }>(
+      'SELECT id, title FROM movies WHERE id = $1',
+      [movie_id],
+    );
+    if (!movie) {
+      return {
+        content: [
+          { type: 'text', text: `❌ Movie [${movie_id}] not found.` },
+        ],
+      };
+    }
+
+    const [show] = await query<{ id: number; title: string }>(
+      'SELECT id, title FROM tvshows WHERE id = $1',
+      [tvshow_id],
+    );
+    if (!show) {
+      return {
+        content: [
+          { type: 'text', text: `❌ TV Show [${tvshow_id}] not found.` },
+        ],
+      };
+    }
+
+    const [existing] = await query<{ movie_id: number }>(
+      'SELECT movie_id FROM related_content WHERE movie_id = $1 AND tvshow_id = $2',
+      [movie_id, tvshow_id],
+    );
+    if (existing) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `⚠️ "${movie.title}" is already linked to "${show.title}".`,
+          },
+        ],
+      };
+    }
+
+    await query(
+      'INSERT INTO related_content (movie_id, tvshow_id) VALUES ($1, $2)',
+      [movie_id, tvshow_id],
+    );
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `✅ Linked: "${movie.title}" ↔ "${show.title}"`,
+        },
+      ],
+    };
+  },
+);
+
 // ─── BULK IMPORT ───────────────────────────────────────────────────────────────
 
 server.registerTool(

--- a/src/modules/movies/entities/IMovie.ts
+++ b/src/modules/movies/entities/IMovie.ts
@@ -1,3 +1,5 @@
+import ITVShow from '@modules/tvshows/entities/ITVShow';
+
 export default interface IMovie {
   id: number;
 
@@ -41,6 +43,8 @@ export default interface IMovie {
   timeline_ends_at?: string;
 
   related_movies?: IMovie[];
+
+  related_tvshows?: ITVShow[];
 
   updated_at?: Date;
 }

--- a/src/modules/movies/infra/http/presenters/MoviePresenter.spec.ts
+++ b/src/modules/movies/infra/http/presenters/MoviePresenter.spec.ts
@@ -1,4 +1,5 @@
 import IMovie from '@modules/movies/entities/IMovie';
+import ITVShow from '@modules/tvshows/entities/ITVShow';
 import { presentMovie, presentMovieCollection } from './MoviePresenter';
 
 const baseUrl = 'http://localhost:3333';
@@ -31,6 +32,20 @@ describe('MoviePresenter', () => {
 
     expect(presented._links.related_movies).toEqual([{ href: `${baseUrl}/api/v1/movies/2` }]);
     expect(presented.related_movies).toBeUndefined();
+  });
+
+  it('Should omit related_tvshows link when the relation is not loaded', () => {
+    const presented = presentMovie(movie, baseUrl);
+
+    expect(presented._links.related_tvshows).toBeUndefined();
+  });
+
+  it('Should link related_tvshows without embedding the full related tvshow data', () => {
+    const related = { id: 3, title: 'Loki' } as ITVShow;
+    const presented = presentMovie({ ...movie, related_tvshows: [related] }, baseUrl);
+
+    expect(presented._links.related_tvshows).toEqual([{ href: `${baseUrl}/api/v1/tvshows/3` }]);
+    expect(presented.related_tvshows).toBeUndefined();
   });
 
   it('Should skip id-dependent links when id is missing (columns selection)', () => {

--- a/src/modules/movies/infra/http/presenters/MoviePresenter.ts
+++ b/src/modules/movies/infra/http/presenters/MoviePresenter.ts
@@ -24,7 +24,11 @@ export function presentMovie(movie: IMovie, baseUrl: string): WithLinks<IMovie> 
     _links.characters = { href: `${baseUrl}/api/v1/characters/movie/${movie.id}` };
   }
 
-  const { related_movies, ...movieWithoutRelatedMovies } = movie;
+  const {
+    related_movies,
+    related_tvshows,
+    ...movieWithoutRelations
+  } = movie;
 
   if (Array.isArray(related_movies)) {
     _links.related_movies = related_movies
@@ -32,7 +36,13 @@ export function presentMovie(movie: IMovie, baseUrl: string): WithLinks<IMovie> 
       .map<ILink>(related => ({ href: `${baseUrl}/api/v1/movies/${related.id}` }));
   }
 
-  return { ...movieWithoutRelatedMovies, _links };
+  if (Array.isArray(related_tvshows)) {
+    _links.related_tvshows = related_tvshows
+      .filter(related => related.id != null)
+      .map<ILink>(related => ({ href: `${baseUrl}/api/v1/tvshows/${related.id}` }));
+  }
+
+  return { ...movieWithoutRelations, _links };
 }
 
 export function presentMovieCollection({

--- a/src/modules/movies/infra/typeorm/entities/Movie.ts
+++ b/src/modules/movies/infra/typeorm/entities/Movie.ts
@@ -1,4 +1,5 @@
 import IMovie from '@modules/movies/entities/IMovie';
+import TVShow from '@modules/tvshows/infra/typeorm/entities/TVShow';
 import {
   Column,
   Entity,
@@ -88,6 +89,14 @@ class Movie implements IMovie {
     inverseJoinColumns: [{ name: 'related_movie_id' }],
   })
   related_movies?: Movie[];
+
+  @ManyToMany(() => TVShow)
+  @JoinTable({
+    name: 'related_content',
+    joinColumns: [{ name: 'movie_id' }],
+    inverseJoinColumns: [{ name: 'tvshow_id' }],
+  })
+  related_tvshows?: TVShow[];
 
   @UpdateDateColumn({
     type: 'timestamp',

--- a/src/modules/movies/infra/typeorm/repositories/MoviesRepository.ts
+++ b/src/modules/movies/infra/typeorm/repositories/MoviesRepository.ts
@@ -27,7 +27,7 @@ class MoviesRepository implements IMoviesRepository {
 
   public async findById(id: number): Promise<Movie | undefined> {
     const findMovie = await this.ormRepository.findOne(id, {
-      relations: ['related_movies'],
+      relations: ['related_movies', 'related_tvshows'],
     });
 
     return findMovie;

--- a/src/modules/tvshows/entities/ITVShow.ts
+++ b/src/modules/tvshows/entities/ITVShow.ts
@@ -1,3 +1,5 @@
+import IMovie from '@modules/movies/entities/IMovie';
+
 export default interface ITVShow {
   id: number;
   title: string;
@@ -27,4 +29,6 @@ export default interface ITVShow {
   timeline_chronology_order?: number;
   timeline_starts_at?: string;
   timeline_ends_at?: string;
+
+  related_movies?: IMovie[];
 }

--- a/src/modules/tvshows/infra/http/presenters/TVShowPresenter.spec.ts
+++ b/src/modules/tvshows/infra/http/presenters/TVShowPresenter.spec.ts
@@ -1,3 +1,4 @@
+import IMovie from '@modules/movies/entities/IMovie';
 import ITVShow from '@modules/tvshows/entities/ITVShow';
 import { presentTVShow, presentTVShowCollection } from './TVShowPresenter';
 
@@ -23,6 +24,20 @@ describe('TVShowPresenter', () => {
     const presented = presentTVShow({ title: 'Loki' } as ITVShow, baseUrl);
 
     expect(presented._links).toEqual({});
+  });
+
+  it('Should omit related_movies link when the relation is not loaded', () => {
+    const presented = presentTVShow(tvshow, baseUrl);
+
+    expect(presented._links.related_movies).toBeUndefined();
+  });
+
+  it('Should link related_movies without embedding the full related movie data', () => {
+    const related = { id: 1, title: 'Avengers: Endgame' } as IMovie;
+    const presented = presentTVShow({ ...tvshow, related_movies: [related] }, baseUrl);
+
+    expect(presented._links.related_movies).toEqual([{ href: `${baseUrl}/api/v1/movies/1` }]);
+    expect(presented.related_movies).toBeUndefined();
   });
 
   it('Should wrap collections with pagination metadata and links', () => {

--- a/src/modules/tvshows/infra/http/presenters/TVShowPresenter.ts
+++ b/src/modules/tvshows/infra/http/presenters/TVShowPresenter.ts
@@ -1,5 +1,6 @@
 import ITVShow from '@modules/tvshows/entities/ITVShow';
 import {
+  ILink,
   IResourceLinks,
   WithLinks,
   buildPaginationLinks,
@@ -23,7 +24,15 @@ export function presentTVShow(tvshow: ITVShow, baseUrl: string): WithLinks<ITVSh
     _links.characters = { href: `${baseUrl}/api/v1/characters/tvshow/${tvshow.id}` };
   }
 
-  return { ...tvshow, _links };
+  const { related_movies, ...tvshowWithoutRelations } = tvshow;
+
+  if (Array.isArray(related_movies)) {
+    _links.related_movies = related_movies
+      .filter(related => related.id != null)
+      .map<ILink>(related => ({ href: `${baseUrl}/api/v1/movies/${related.id}` }));
+  }
+
+  return { ...tvshowWithoutRelations, _links };
 }
 
 export function presentTVShowCollection({

--- a/src/modules/tvshows/infra/typeorm/entities/TVShow.ts
+++ b/src/modules/tvshows/infra/typeorm/entities/TVShow.ts
@@ -3,7 +3,6 @@ import Movie from '@modules/movies/infra/typeorm/entities/Movie';
 import {
   Column,
   Entity,
-  JoinTable,
   ManyToMany,
   PrimaryColumn,
   UpdateDateColumn,
@@ -89,12 +88,7 @@ class TVShow implements ITVShow {
   @Column('varchar', { nullable: true })
   timeline_ends_at: string;
 
-  @ManyToMany(() => Movie)
-  @JoinTable({
-    name: 'related_content',
-    joinColumns: [{ name: 'tvshow_id' }],
-    inverseJoinColumns: [{ name: 'movie_id' }],
-  })
+  @ManyToMany(() => Movie, movie => movie.related_tvshows)
   related_movies?: Movie[];
 }
 

--- a/src/modules/tvshows/infra/typeorm/entities/TVShow.ts
+++ b/src/modules/tvshows/infra/typeorm/entities/TVShow.ts
@@ -1,5 +1,13 @@
 import ITVShow from '@modules/tvshows/entities/ITVShow';
-import { Column, Entity, PrimaryColumn, UpdateDateColumn } from 'typeorm';
+import Movie from '@modules/movies/infra/typeorm/entities/Movie';
+import {
+  Column,
+  Entity,
+  JoinTable,
+  ManyToMany,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 
 @Entity({ name: 'tvshows', schema: 'public' })
 class TVShow implements ITVShow {
@@ -80,6 +88,14 @@ class TVShow implements ITVShow {
 
   @Column('varchar', { nullable: true })
   timeline_ends_at: string;
+
+  @ManyToMany(() => Movie)
+  @JoinTable({
+    name: 'related_content',
+    joinColumns: [{ name: 'tvshow_id' }],
+    inverseJoinColumns: [{ name: 'movie_id' }],
+  })
+  related_movies?: Movie[];
 }
 
 export default TVShow;

--- a/src/modules/tvshows/infra/typeorm/repositories/TVShowsRepository.ts
+++ b/src/modules/tvshows/infra/typeorm/repositories/TVShowsRepository.ts
@@ -13,7 +13,9 @@ class TVShowsRepository implements ITVShowsRepository {
   }
 
   public async findById(id: number): Promise<ITVShow | undefined> {
-    const tvshow = await this.ormRepository.findOne(id);
+    const tvshow = await this.ormRepository.findOne(id, {
+      relations: ['related_movies'],
+    });
 
     return tvshow;
   }

--- a/src/shared/infra/typeorm/migrations/1785184415561-CreateRelatedContent.ts
+++ b/src/shared/infra/typeorm/migrations/1785184415561-CreateRelatedContent.ts
@@ -1,0 +1,57 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+} from 'typeorm';
+
+export default class CreateRelatedContent1785184415561
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'related_content',
+        columns: [
+          {
+            name: 'movie_id',
+            type: 'int',
+          },
+          {
+            name: 'tvshow_id',
+            type: 'int',
+          },
+        ],
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'related_content',
+      new TableForeignKey({
+        name: 'FKRelatedContentMovieId',
+        referencedTableName: 'movies',
+        referencedColumnNames: ['id'],
+        columnNames: ['movie_id'],
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'related_content',
+      new TableForeignKey({
+        name: 'FKRelatedContentTVShowId',
+        referencedTableName: 'tvshows',
+        referencedColumnNames: ['id'],
+        columnNames: ['tvshow_id'],
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropForeignKey('related_content', 'FKRelatedContentMovieId');
+    await queryRunner.dropForeignKey('related_content', 'FKRelatedContentTVShowId');
+    await queryRunner.dropTable('related_content');
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a bidirectional many-to-many `related_content` relation between movies and tvshows, mirroring the existing `related_movies` self-relation pattern
- Movies gain `related_tvshows` (embed-free, links-only per current HATEOAS convention), TV shows gain the symmetric `related_movies`
- New `link_related_content` MCP tool writes the relation (movie_id/tvshow_id, existence checks, duplicate guard), consistent with the read-only public API

Closes #38

## Test plan

- [x] Unit tests pass (`npm test`) — 19 suites, 69 tests
- [x] `tsc --noEmit` passes (no lint/typecheck npm scripts exist in this repo)
- [x] Presenter specs cover new `related_tvshows`/`related_movies` link behavior (present + absent cases)
- [ ] Migration run against a live DB (`npm run typeorm:dev migration:run`)
- [ ] Manual: `link_related_content` MCP tool against Neon

🤖 Generated with [Claude Code](https://claude.ai/claude-code)