### PR TITLE
feat(tvshows): add self-referential related_tvshows relation

### DIFF
--- a/mcuapi-mcp/src/index.ts
+++ b/mcuapi-mcp/src/index.ts
@@ -952,6 +952,84 @@ server.registerTool(
   },
 );
 
+server.registerTool(
+  'link_related_tvshows',
+  {
+    description: 'Link two TV shows as related content (bidirectional).',
+    inputSchema: {
+      tvshow_id: z.number().int(),
+      related_tvshow_id: z.number().int(),
+    },
+  },
+  async ({ tvshow_id, related_tvshow_id }) => {
+    const [tvshow] = await query<{ id: number; title: string }>(
+      'SELECT id, title FROM tvshows WHERE id = $1',
+      [tvshow_id],
+    );
+    if (!tvshow) {
+      return {
+        content: [
+          { type: 'text', text: `❌ TV Show [${tvshow_id}] not found.` },
+        ],
+      };
+    }
+
+    const [related] = await query<{ id: number; title: string }>(
+      'SELECT id, title FROM tvshows WHERE id = $1',
+      [related_tvshow_id],
+    );
+    if (!related) {
+      return {
+        content: [
+          { type: 'text', text: `❌ TV Show [${related_tvshow_id}] not found.` },
+        ],
+      };
+    }
+
+    const [forward] = await query<{ tvshow_id: number }>(
+      'SELECT tvshow_id FROM related_tvshows WHERE tvshow_id = $1 AND related_tvshow_id = $2',
+      [tvshow_id, related_tvshow_id],
+    );
+    if (!forward) {
+      await query(
+        'INSERT INTO related_tvshows (tvshow_id, related_tvshow_id) VALUES ($1, $2)',
+        [tvshow_id, related_tvshow_id],
+      );
+    }
+
+    const [backward] = await query<{ tvshow_id: number }>(
+      'SELECT tvshow_id FROM related_tvshows WHERE tvshow_id = $1 AND related_tvshow_id = $2',
+      [related_tvshow_id, tvshow_id],
+    );
+    if (!backward) {
+      await query(
+        'INSERT INTO related_tvshows (tvshow_id, related_tvshow_id) VALUES ($1, $2)',
+        [related_tvshow_id, tvshow_id],
+      );
+    }
+
+    if (forward && backward) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `⚠️ "${tvshow.title}" is already linked to "${related.title}".`,
+          },
+        ],
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `✅ Linked: "${tvshow.title}" ↔ "${related.title}"`,
+        },
+      ],
+    };
+  },
+);
+
 // ─── BULK IMPORT ───────────────────────────────────────────────────────────────
 
 server.registerTool(

--- a/src/modules/tvshows/entities/ITVShow.ts
+++ b/src/modules/tvshows/entities/ITVShow.ts
@@ -28,4 +28,6 @@ export default interface ITVShow {
   timeline_chronology_order?: number;
 
   related_movies?: IMovie[];
+
+  related_tvshows?: ITVShow[];
 }

--- a/src/modules/tvshows/infra/http/presenters/TVShowPresenter.spec.ts
+++ b/src/modules/tvshows/infra/http/presenters/TVShowPresenter.spec.ts
@@ -40,6 +40,20 @@ describe('TVShowPresenter', () => {
     expect(presented.related_movies).toBeUndefined();
   });
 
+  it('Should omit related_tvshows link when the relation is not loaded', () => {
+    const presented = presentTVShow(tvshow, baseUrl);
+
+    expect(presented._links.related_tvshows).toBeUndefined();
+  });
+
+  it('Should link related_tvshows without embedding the full related tvshow data', () => {
+    const related = { id: 2, title: 'Hawkeye' } as ITVShow;
+    const presented = presentTVShow({ ...tvshow, related_tvshows: [related] }, baseUrl);
+
+    expect(presented._links.related_tvshows).toEqual([{ href: `${baseUrl}/api/v1/tvshows/2` }]);
+    expect(presented.related_tvshows).toBeUndefined();
+  });
+
   it('Should wrap collections with pagination metadata and links', () => {
     const collection = presentTVShowCollection({
       data: [tvshow],

--- a/src/modules/tvshows/infra/http/presenters/TVShowPresenter.ts
+++ b/src/modules/tvshows/infra/http/presenters/TVShowPresenter.ts
@@ -24,12 +24,22 @@ export function presentTVShow(tvshow: ITVShow, baseUrl: string): WithLinks<ITVSh
     _links.characters = { href: `${baseUrl}/api/v1/characters/tvshow/${tvshow.id}` };
   }
 
-  const { related_movies, ...tvshowWithoutRelations } = tvshow;
+  const {
+    related_movies,
+    related_tvshows,
+    ...tvshowWithoutRelations
+  } = tvshow;
 
   if (Array.isArray(related_movies)) {
     _links.related_movies = related_movies
       .filter(related => related.id != null)
       .map<ILink>(related => ({ href: `${baseUrl}/api/v1/movies/${related.id}` }));
+  }
+
+  if (Array.isArray(related_tvshows)) {
+    _links.related_tvshows = related_tvshows
+      .filter(related => related.id != null)
+      .map<ILink>(related => ({ href: `${baseUrl}/api/v1/tvshows/${related.id}` }));
   }
 
   return { ...tvshowWithoutRelations, _links };

--- a/src/modules/tvshows/infra/typeorm/entities/TVShow.ts
+++ b/src/modules/tvshows/infra/typeorm/entities/TVShow.ts
@@ -3,6 +3,7 @@ import Movie from '@modules/movies/infra/typeorm/entities/Movie';
 import {
   Column,
   Entity,
+  JoinTable,
   ManyToMany,
   PrimaryColumn,
   UpdateDateColumn,
@@ -81,6 +82,14 @@ class TVShow implements ITVShow {
 
   @ManyToMany(() => Movie, movie => movie.related_tvshows)
   related_movies?: Movie[];
+
+  @ManyToMany(() => TVShow)
+  @JoinTable({
+    name: 'related_tvshows',
+    joinColumns: [{ name: 'tvshow_id' }],
+    inverseJoinColumns: [{ name: 'related_tvshow_id' }],
+  })
+  related_tvshows?: TVShow[];
 }
 
 export default TVShow;

--- a/src/modules/tvshows/infra/typeorm/repositories/TVShowsRepository.ts
+++ b/src/modules/tvshows/infra/typeorm/repositories/TVShowsRepository.ts
@@ -14,7 +14,7 @@ class TVShowsRepository implements ITVShowsRepository {
 
   public async findById(id: number): Promise<ITVShow | undefined> {
     const tvshow = await this.ormRepository.findOne(id, {
-      relations: ['related_movies'],
+      relations: ['related_movies', 'related_tvshows'],
     });
 
     return tvshow;

--- a/src/shared/infra/typeorm/migrations/1785790668577-CreateRelatedTVShows.ts
+++ b/src/shared/infra/typeorm/migrations/1785790668577-CreateRelatedTVShows.ts
@@ -1,0 +1,57 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+} from 'typeorm';
+
+export default class CreateRelatedTVShows1785790668577
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'related_tvshows',
+        columns: [
+          {
+            name: 'tvshow_id',
+            type: 'int',
+          },
+          {
+            name: 'related_tvshow_id',
+            type: 'int',
+          },
+        ],
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'related_tvshows',
+      new TableForeignKey({
+        name: 'FKTVShowId',
+        referencedTableName: 'tvshows',
+        referencedColumnNames: ['id'],
+        columnNames: ['tvshow_id'],
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'related_tvshows',
+      new TableForeignKey({
+        name: 'FKRelatedTVShowId',
+        referencedTableName: 'tvshows',
+        referencedColumnNames: ['id'],
+        columnNames: ['related_tvshow_id'],
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropForeignKey('related_tvshows', 'FKTVShowId');
+    await queryRunner.dropForeignKey('related_tvshows', 'FKRelatedTVShowId');
+    await queryRunner.dropTable('related_tvshows');
+  }
+}


### PR DESCRIPTION
## Summary

- New `related_tvshows` join table (migration) mirroring `related_movies`, with cascading FKs to `tvshows.id`
- `TVShow` entity/interface gain a self-referential `related_tvshows` relation, loaded by `TVShowsRepository.findById`
- `TVShowPresenter` exposes `_links.related_tvshows`, matching how `MoviePresenter` handles `related_movies`
- New MCP tool `link_related_tvshows` for bidirectionally linking two TV shows, mirroring `link_related_movies`

Closes #42

## Test plan

- [x] Unit tests pass (`npm test`) — 74/74 passing, including new `TVShowPresenter` coverage
- [x] Build/typecheck passes (`npm run build`) for the API
- [x] `mcuapi-mcp` typechecks (`npx tsc --noEmit`)
- [ ] Manual: run migration against a DB and use `link_related_tvshows` via MCP to link two shows, then confirm `GET /api/v1/tvshows/:id` returns `_links.related_tvshows`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)